### PR TITLE
Patch for new upcoming cljs version

### DIFF
--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -249,6 +249,7 @@
        (when-let [[_ & ms] (re-matches* re route)]
          (->> (interleave params (map decode ms))
               (partition 2)
+              (map (fn [[k v]] (MapEntry. k v nil)))
               (merge-with vector {})))))))
 
 ;;----------------------------------------------------------------------


### PR DESCRIPTION
See https://github.com/clojure/clojurescript/commit/c61a2358a6ff7d9f5aa8c50843c29580293be861
Without this patch, secretary will fail on the upcoming ClojureScript.